### PR TITLE
Memgraph 2.18.1

### DIFF
--- a/.github/workflows/kubelint.yaml
+++ b/.github/workflows/kubelint.yaml
@@ -48,29 +48,18 @@ jobs:
       with:
         directory: config/manifests
         config: ${GITHUB_WORKSPACE}/.github/config_files/config_lint.yaml
-        version: $KUBELINTER_VERSION 
+        version: $KUBELINTER_VERSION
 
     - name: Scan directory ./config/samples/ with kube-linter
       uses: stackrox/kube-linter-action@v1.0.3
       with:
         directory: config/samples
         config: ${GITHUB_WORKSPACE}/.github/config_files/config_lint.yaml
-        version: $KUBELINTER_VERSION 
+        version: $KUBELINTER_VERSION
 
     - name: Scan directory ./config/scorecard/ with kube-linter
       uses: stackrox/kube-linter-action@v1.0.3
       with:
         directory: config/scorecard
         config: ${GITHUB_WORKSPACE}/.github/config_files/config_lint.yaml
-        version: $KUBELINTER_VERSION 
-
-
-
-
-
-
-
-
-
-
-
+        version: $KUBELINTER_VERSION

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,28 @@
+name: Pre-commit
+
+on: pull_request
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2  # fetches all history so pre-commit can run properly
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'  # Use Python 3.9
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files --show-diff-on-failure
+
+    - name: Cache the pre-commit environment
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "helm-charts"]
 	path = helm-charts
-	url = https://github.com/memgraph/helm-charts.git
+  url = https://github.com/memgraph/helm-charts.git
+  branch = main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+    exclude: ^charts/memgraph/templates/
+  - id: check-json
+  - id: mixed-line-ending
+  - id: check-merge-conflict
+  - id: detect-private-key

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.2
+VERSION ?= 0.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -28,7 +28,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-u my.domain/kubernetes-operator-bundle:$VERSION and my.domain/kubernetes-operator-catalog:$VERSION.
+# my.domain/kubernetes-operator-bundle:$VERSION and my.domain/kubernetes-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= memgraph/kubernetes-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
@@ -232,7 +232,6 @@ HELMIFY ?= helmify
 helmify: $(HELMIFY) ## Download helmify locally if necessary.
 $(HELMIFY): $(LOCALBIN)
 	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
-    
+
 helm: config/manifests kustomize helmify
 	$(KUSTOMIZE) build config/default | $(HELMIFY)
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Memgraph Kubernetes Operator is WIP. You can currently install the operator and manage the deployment of Memgraph's High Availability cluster
-through it. 
+through it.
 
 ## Table of Contents
 
@@ -13,8 +13,8 @@ through it.
 
 ## Prerequisites
 
-We use Go version 1.22.5 (not needed at the moment). Check out here how to [install Go](https://go.dev/doc/install). 
-The current Helm version is v3.14.4.
+We use Go version 1.22.5 (not needed at the moment). Check out here how to [install Go](https://go.dev/doc/install).
+The current Helm version used is v3.14.4.
 
 ## Documentation
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,9 @@
 resources:
+- namespace.yaml
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: memgraph-kubernetes-operator
   newName: memgraph/kubernetes-operator
-  newTag: 0.0.2
+  newTag: 0.0.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: memgraph-operator-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
       - args:
-        image: memgraph/kubernetes-operator:0.0.2
+        image: memgraph/kubernetes-operator:0.0.3  # TODO: (andi) Try to specify this in a single place, currently used by kustomization.yaml and Makefile
         name: manager
         securityContext:
           readOnlyRootFilesystem: true

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: memgraph-operator-system

--- a/config/samples/memgraph_v1_ha.yaml
+++ b/config/samples/memgraph_v1_ha.yaml
@@ -84,7 +84,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: memgraph/memgraph
-      tag: 2.18.0
+      tag: 2.18.0_27_0b62e6a73
     probes:
       liveness:
         initialDelaySeconds: 30

--- a/config/samples/memgraph_v1_ha.yaml
+++ b/config/samples/memgraph_v1_ha.yaml
@@ -3,84 +3,102 @@ kind: MemgraphHA
 metadata:
   name: memgraphha-sample
 spec:
-  # Default values copied from <project_dir>/helm-charts/memgraph-high-availability/values.yaml
   coordinators:
-  - args:
+  - id: "1"
+    boltPort: 7687
+    managementPort: 10000
+    coordinatorPort: 12000
+    args:
     - --experimental-enabled=high-availability
     - --coordinator-id=1
     - --coordinator-port=12000
+    - --management-port=10000
     - --bolt-port=7687
     - --also-log-to-stderr
     - --log-level=TRACE
     - --coordinator-hostname=memgraph-coordinator-1.default.svc.cluster.local
+    - --log-file=/var/log/memgraph/memgraph.log
+    - --nuraft-log-file=/var/log/memgraph/memgraph.log
+
+  - id: "2"
     boltPort: 7687
+    managementPort: 10000
     coordinatorPort: 12000
-    id: "1"
-  - args:
+    args:
     - --experimental-enabled=high-availability
     - --coordinator-id=2
     - --coordinator-port=12000
+    - --management-port=10000
     - --bolt-port=7687
     - --also-log-to-stderr
     - --log-level=TRACE
     - --coordinator-hostname=memgraph-coordinator-2.default.svc.cluster.local
+    - --log-file=/var/log/memgraph/memgraph.log
+    - --nuraft-log-file=/var/log/memgraph/memgraph.log
+
+  - id: "3"
     boltPort: 7687
+    managementPort: 10000
     coordinatorPort: 12000
-    id: "2"
-  - args:
+    args:
     - --experimental-enabled=high-availability
     - --coordinator-id=3
     - --coordinator-port=12000
+    - --management-port=10000
     - --bolt-port=7687
     - --also-log-to-stderr
     - --log-level=TRACE
     - --coordinator-hostname=memgraph-coordinator-3.default.svc.cluster.local
-    boltPort: 7687
-    coordinatorPort: 12000
-    id: "3"
+    - --log-file=/var/log/memgraph/memgraph.log
+    - --nuraft-log-file=/var/log/memgraph/memgraph.log
+
+
   data:
-  - args:
+  - id: "0"
+    boltPort: 7687
+    managementPort: 10000
+    replicationPort: 20000
+    args:
     - --experimental-enabled=high-availability
     - --management-port=10000
     - --bolt-port=7687
     - --also-log-to-stderr
     - --log-level=TRACE
-    - --replication-restore-state-on-startup=true
+    - --log-file=/var/log/memgraph/memgraph.log
+
+  - id: "1"
     boltPort: 7687
-    id: "0"
     managementPort: 10000
     replicationPort: 20000
-  - args:
+    args:
     - --experimental-enabled=high-availability
     - --management-port=10000
     - --bolt-port=7687
     - --also-log-to-stderr
     - --log-level=TRACE
-    - --replication-restore-state-on-startup=true
-    boltPort: 7687
-    id: "1"
-    managementPort: 10000
-    replicationPort: 20000
+    - --log-file=/var/log/memgraph/memgraph.log
+
   memgraph:
-    coordinators:
-      volumeClaim:
-        logPVC: false
-        logPVCClassName: ""
-        logPVCSize: 256Mi
-        storagePVC: false
-        storagePVCClassName: ""
-        storagePVCSize: 1Gi
     data:
       volumeClaim:
-        logPVC: false
-        logPVCClassName: ""
-        logPVCSize: 256Mi
-        storagePVC: false
         storagePVCClassName: ""
+        storagePVC: true
         storagePVCSize: 1Gi
+        logPVCClassName: ""
+        logPVC: true
+        logPVCSize: 256Mi
+    coordinators:
+      volumeClaim:
+        logPVCClassName: ""
+        logPVC: false # TODO: (andi) Fix
+        logPVCSize: 256Mi
+        storagePVCClassName: ""
+        storagePVC: true
+        storagePVCSize: 1Gi
+
     env:
-      MEMGRAPH_ENTERPRISE_LICENSE: ""
-      MEMGRAPH_ORGANIZATION_NAME: ""
+      MEMGRAPH_ENTERPRISE_LICENSE: "${MEMGRAPH_ENTERPRISE_LICENSE}"
+      MEMGRAPH_ORGANIZATION_NAME: "${MEMGRAPH_ORGANIZATION_NAME}"
     image:
       pullPolicy: IfNotPresent
       repository: memgraph/memgraph
@@ -95,5 +113,3 @@ spec:
       startup:
         failureThreshold: 30
         periodSeconds: 10
-  
-  

--- a/config/samples/memgraph_v1_ha.yaml
+++ b/config/samples/memgraph_v1_ha.yaml
@@ -90,7 +90,7 @@ spec:
     coordinators:
       volumeClaim:
         logPVCClassName: ""
-        logPVC: false # TODO: (andi) Fix
+        logPVC: true
         logPVCSize: 256Mi
         storagePVCClassName: ""
         storagePVC: true
@@ -102,7 +102,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: memgraph/memgraph
-      tag: 2.18.0_27_0b62e6a73
+      tag: 2.18.0
     probes:
       liveness:
         initialDelaySeconds: 30

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,11 +30,11 @@ Installation using any of options described above will cause creating Kubernetes
 namespace `memgraph-operator-system`. You can check your resources with:
 
 ```bash
-kubectl get serviceaccounts -A
-kubectl get rolebindings -A
-kubectl get roles -A
-kubectl get deployments -A
-kubectl get pods -A
+kubectl get serviceaccounts -n memgraph-operator-system
+kubectl get clusterrolebindings -n memgraph-operator-system
+kubectl get clusterroles -n memgraph-operator-system
+kubectl get deployments -n memgraph-operator-system
+kubectl get pods -n memgraph-operator-system
 ```
 
 CustomResourceDefinition `memgraphhas.memgraph.com`, whose job is to monitor CustomResource `MemgraphHA`, will also get created and you can verify

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,12 +46,19 @@ kubectl get crds -A
 
 ## Start Memgraph High Availability Cluster
 
-We already provide sample cluster in `config/samples/memgraph_v1_ha.yaml`. You only need to set your license information by setting 
-`MEMGRAPH_ORGANIZATION_NAME` and `MEMGRAPH_ENTERPRISE_LICENSE` environment variables in the sample file.
+We already provide sample cluster in `config/samples/memgraph_v1_ha.yaml`. You only need to set your license information by setting
+environment variables `MEMGRAPH_ORGANIZATION_NAME` and `MEMGRAPH_ENTERPRISE_LICENSE` in your local environment with:
 
-Start Memgraph HA cluster with `kubectl apply -f config/samples/memgraph_v1_ha.yaml`.
+```bash
+export MEMGRAPH_ORGANIZATION_NAME="<YOUR_ORGANIZATION_NAME>"
+export MEMGRAPH_ENTERPRISE_LICENSE="<MEMGRAPH_ENTERPRISE_LICENSE>"
+```
 
-After approx. 60s, you should be able to see instances in the output of `kubectl get pods -A`:
+Start Memgraph HA cluster with `envsubst < config/samples/memgraph_v1_ha.yaml | kubectl apply -f -`. (The `envsubst command` is a part of the gettext package.)
+Instead of using `envsubst` command, you can directly set environment variables in `config/samples/memgraph_v1_ha.yaml`.
+
+
+After ~40s, you should be able to see instances in the output of `kubectl get pods -A`:
 
 
 You can now find URL of any coordinator instances by running e.g `minikube service list` and connect to see the state of the cluster by running

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,6 @@
 
 All described installation options will run the Operator inside the cluster.
 
-## Option I: Install using Makefile
 
 Make sure to clone this repository with its submodule (helm-charts).
 
@@ -10,19 +9,13 @@ Make sure to clone this repository with its submodule (helm-charts).
 git clone --recurse-submodules git@github.com:memgraph/kubernetes-operator.git
 ```
 
-After this you can start your operator with a single command:
-
-```bash
-make deploy
-```
-
-This command will use operator's image from Memgraph's DockerHub and create all necessary Kubernetes resources for running an operator.
-
-## Option II: Install using kubectl
+## Install K8 resources
 
 ```bash
 kubectl apply -k config/default
 ```
+
+This command will use operator's image from Memgraph's DockerHub and create all necessary Kubernetes resources for running an operator.
 
 ## Verify installation
 
@@ -54,7 +47,7 @@ export MEMGRAPH_ORGANIZATION_NAME="<YOUR_ORGANIZATION_NAME>"
 export MEMGRAPH_ENTERPRISE_LICENSE="<MEMGRAPH_ENTERPRISE_LICENSE>"
 ```
 
-Start Memgraph HA cluster with `envsubst < config/samples/memgraph_v1_ha.yaml | kubectl apply -f -`. (The `envsubst command` is a part of the gettext package.)
+Start Memgraph HA cluster with `envsubst < config/samples/memgraph_v1_ha.yaml | kubectl apply -f -`. (The `envsubst command` is a part of the `gettext` package.)
 Instead of using `envsubst` command, you can directly set environment variables in `config/samples/memgraph_v1_ha.yaml`.
 
 
@@ -70,5 +63,6 @@ You can now find URL of any coordinator instances by running e.g `minikube servi
 
 ```bash
 kubectl delete -f config/samples/memgraph_v1_ha.yaml
-make undeploy / or kubectl delete -k config/default
+kubectl delete pvc --all  # Or leave them if you want to use persistent storage
+kubectl delete -k config/default
 ```


### PR DESCRIPTION
- Added pre-commit hook.
- Pushed new version (0.0.3) of operator to DockerHub with changes relevant to 2.18.1.
- Separated namespace creation into a separate yaml file.
- Improved installation procedure by using `envsubst`
- Updated sample file with changes for 2.18.1:
  - coordinators started with mgmt flag
  - added log files
  - added pvcs

